### PR TITLE
only accept numeric values

### DIFF
--- a/marathon.py
+++ b/marathon.py
@@ -16,6 +16,7 @@
 import collectd
 import json
 import urllib2
+import numbers
 
 PREFIX = "marathon"
 MARATHON_HOST = "localhost"
@@ -75,8 +76,8 @@ def read_callback():
 
 def dispatch_stat(type, name, value, instance, verbose_logging):
     """Read a key from info response data and dispatch a value"""
-    if value is None:
-        collectd.warning('marathon plugin: Value not found for %s' % name)
+    if not isinstance(value, numbers.Number):
+        collectd.warning('marathon plugin: incorrect value found for %s' % name)
         return
 
     log_verbose('Sending value[%s]: %s=%s' % (type, name, value), verbose_logging)


### PR DESCRIPTION
This may just be a recent change in Marathon metrics. But the latest 0.15.2 release throws this for the `jvm.threads.deadlocks.value` metric.

```
collectd_1 | [2016-02-29 14:40:40] marathon plugin [verbose]: Sending value[gauge]: jvm.threads.deadlocks.value=[]
collectd_1 | [2016-02-29 14:40:40] Unhandled python exception in read callback: TypeError: float() argument must be a string or a number
collectd_1 | [2016-02-29 14:40:40] Traceback (most recent call last):
collectd_1 | [2016-02-29 14:40:40]   File "/usr/share/collectd/plugins/marathon.py", line 71, in read_callback
collectd_1 |     dispatch_stat('gauge', '.'.join((name, metric)), value, config['instance'], config['verbose_logging'])
collectd_1 | [2016-02-29 14:40:40]   File "/usr/share/collectd/plugins/marathon.py", line 91, in dispatch_stat
collectd_1 |     val.dispatch()
collectd_1 | [2016-02-29 14:40:40] TypeError: float() argument must be a string or a number
collectd_1 | [2016-02-29 14:40:40] read-function of plugin `python.marathon' failed. Will suspend it for 20.000 seconds.
collectd_1 | No Kafka brokers found using /kafka
collectd_1 | [2016-02-29 14:40:50] mesos-slave plugin [verbose]: Read callback called
collectd_1 | No Kafka brokers found using /kafka
```
